### PR TITLE
[WIP] Memory Pools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ $(TARGET):
 	gcc $(CFLAGS) -I$(INC_PATH) $(SRC_PATH)base/hash.c -o $(OBJ_PATH)hash.o
 	gcc $(CFLAGS) -I$(INC_PATH) $(SRC_PATH)base/util.c -o $(OBJ_PATH)util.o
 	gcc $(CFLAGS) -I$(INC_PATH) $(SRC_PATH)mm.c -o $(OBJ_PATH)mm.o
+	gcc $(CFLAGS) -I$(INC_PATH) $(SRC_PATH)mm_pool.c -o $(OBJ_PATH)mm_pool.o
 	ar rcs $(TARGET) $(OBJ_PATH)*.o
 
 test: $(TEST_BUILD)

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ $(TEST_FILE):
 $(TEST_BUILD): $(TARGET) $(TEST_FILE)
 	mkdir -p test/obj/
 	gcc $(CFLAGS) -I$(INC_PATH) test/src/mm.c -o test/obj/mm.o 
+	gcc $(CFLAGS) -I$(INC_PATH) test/src/mm_pool.c -o test/obj/mm_pool.o 
 	gcc $(CFLAGS) -I$(INC_PATH) test/src/base/stackTest.c -o test/obj/stackTest.o 
 	gcc $(CFLAGS) -I$(INC_PATH) test/src/base/hashTest.c -o test/obj/hashTest.o 
 	gcc $(CFLAGS) -I$(INC_PATH) test/src/base/clistTest.c -o test/obj/clistTest.o 

--- a/include/mm.h
+++ b/include/mm.h
@@ -10,7 +10,7 @@ void D_mm_init();
 
 void* D_mm_alloc(size_t size, D_free_fnc_t free_fnc);
 
-unsigned D_mm_retain(void* ptr);
+void* D_mm_retain(void* ptr);
 
 unsigned D_mm_release(void* ptr);
 

--- a/include/mm_pool.h
+++ b/include/mm_pool.h
@@ -1,0 +1,13 @@
+#ifndef __MM_POOL_H_
+#define __MM_POOL_H_
+
+typedef struct {
+	size_t pools;
+	size_t pool_length;
+} D_mm_pool_conf;
+
+void D_mm_pool_init(D_mm_pool_conf config);
+
+void D_mm_pool_add(void* ptr);
+
+#endif

--- a/include/mm_pool.h
+++ b/include/mm_pool.h
@@ -1,6 +1,8 @@
 #ifndef __MM_POOL_H_
 #define __MM_POOL_H_
 
+#include <stddef.h>
+
 typedef struct {
 	size_t pools;
 	size_t pool_length;
@@ -8,6 +10,8 @@ typedef struct {
 
 void D_mm_pool_init(D_mm_pool_conf config);
 
-void D_mm_pool_add(void* ptr);
+void* D_mm_pool_add(void* ptr);
+
+void D_mm_pool_destroy();
 
 #endif

--- a/src/mm.c
+++ b/src/mm.c
@@ -40,10 +40,12 @@ void* D_mm_alloc(size_t size, D_free_fnc_t free_fnc) {
 	return ret;
 }
 
-unsigned D_mm_retain(void* ptr) {
+void* D_mm_retain(void* ptr) {
 	slot_t* slot = assert_slot(ptr);
 
-	return ++slot->count;
+	++slot->count;
+
+	return ptr;
 }
 
 unsigned D_mm_release(void* ptr) {

--- a/src/mm.c
+++ b/src/mm.c
@@ -105,6 +105,7 @@ static void free_slot(void* ptr) {
 	}
 	free(slot);
 }
+
 static slot_t* assert_slot(void* ptr) {
 	slot_t* slot = d_hash_fetch(references, ptr);
 	if(slot == NULL) {

--- a/src/mm_pool.c
+++ b/src/mm_pool.c
@@ -1,0 +1,58 @@
+#include <base/d_malloc.h>
+#include <base/clist.h>
+#include <mm.h>
+#include <mm_pool.h>
+
+
+static d_clist pools = NULL;
+static d_clist current = NULL;
+
+static D_mm_pool_conf current_config;
+
+static void release_pool(d_clist pool);
+static void add_to_current(void* ptr);
+static void set_next_current();
+static int is_current_full();
+
+void D_mm_pool_init(D_mm_pool_conf config) {
+	current_config = config;
+	pools = d_clist_new(current_config.pools);
+	current = d_clist_new(current_config.pool_length);
+}
+
+void D_mm_pool_add(void *ptr) {
+
+	if(is_current_full()) {
+		set_next_current();
+	}
+
+	add_to_current(ptr);
+}
+
+static int is_current_full() {
+	return d_clist_is_full(current);
+}
+
+static void set_next_current() {
+
+	if(d_clist_is_full(pools)) {
+		release_pool(d_clist_take(pools));
+	}
+
+	d_clist_put(pools, current);
+
+	current = d_clist_new(current_config.pool_length);	
+}
+
+static void add_to_current(void* ptr) {
+	d_clist_put(current, ptr);
+}
+
+static void release_pool(d_clist pool) {
+	while(!d_clist_is_empty(pool)) {
+		D_mm_release(d_clist_take(pool));
+	}
+
+	d_clist_destroy(pool);
+}
+

--- a/test/src/mm.c
+++ b/test/src/mm.c
@@ -49,7 +49,8 @@ void TestMM_retail(CuTest *tc) {
 	CuAssertIntEquals(tc, 1, D_mm_retain_count(z));
 	int j;
 	for(j = 0 ; j < COUNT ; j++) {
-		CuAssertIntEquals(tc, j+2, D_mm_retain(z));
+		D_mm_retain(z);
+		CuAssertIntEquals(tc, j+2, D_mm_retain_count(z));
 	}
 
 	CuAssertIntEquals(tc, COUNT+1, D_mm_retain_count(z));

--- a/test/src/mm_pool.c
+++ b/test/src/mm_pool.c
@@ -1,0 +1,110 @@
+#include <mm_pool.h>
+#include <mm.h>
+
+#include "../cutest/CuTest.h"
+
+typedef struct {
+  int* i;
+} zombie_t;
+
+static unsigned init = 0; 
+static D_mm_pool_conf config = {1, 2};
+
+static void free_zombie(zombie_t* z);
+static zombie_t* new_zombie(int* ptr);
+
+
+static void after();
+static void before();
+
+
+
+void TestPool_adds_doesnt_change_retain(CuTest *tc) {
+  before();
+  void* ptr = D_mm_alloc(8, NULL);
+
+  CuAssertPtrNotNull(tc, ptr);
+
+  D_mm_pool_add(ptr);
+
+  CuAssertIntEquals(tc, 1, D_mm_retain_count(ptr));
+  after();
+}
+
+
+void TestPool_fill_pool(CuTest *tc) {
+  before();
+  // Alloc 2 references, and add it to the pools.
+  void* ptr1 = D_mm_pool_add(D_mm_retain(D_mm_alloc(8, NULL)));
+  void* ptr2 = D_mm_pool_add(D_mm_retain(D_mm_alloc(8, NULL)));
+
+  CuAssertIntEquals(tc, 2, D_mm_retain_count(ptr1));
+  CuAssertIntEquals(tc, 2, D_mm_retain_count(ptr2));
+
+  // Force the current be pushed to the pool
+  D_mm_pool_add(D_mm_alloc(8, NULL));
+  D_mm_pool_add(D_mm_alloc(8, NULL));
+
+  // Force the pool to relase the older references.
+  D_mm_pool_add(D_mm_alloc(8, NULL));
+
+  CuAssertIntEquals(tc, 1, D_mm_retain_count(ptr1));
+  CuAssertIntEquals(tc, 1, D_mm_retain_count(ptr2));  
+
+  after();
+}
+
+void TestPool_fill_pool_free(CuTest *tc) {
+    before();
+  int i = 10;
+  // Alloc 2 references, and add it to the pools.
+  void* ptr1 = D_mm_pool_add(new_zombie(&i));
+  void* ptr2 = D_mm_pool_add(D_mm_alloc(8, NULL));
+
+  CuAssertIntEquals(tc, 1, D_mm_retain_count(ptr1));
+  CuAssertIntEquals(tc, 1, D_mm_retain_count(ptr2));
+
+  // Force the current be pushed to the pool
+  D_mm_pool_add(D_mm_alloc(8, NULL));
+  D_mm_pool_add(D_mm_alloc(8, NULL));
+
+  // Force the pool to relase the older references.
+  D_mm_pool_add(D_mm_alloc(8, NULL));
+
+  CuAssertIntEquals(tc, 0, i);
+
+  after();
+}
+
+
+
+static void after() {
+  if(init) {
+    D_mm_pool_destroy();
+    D_mm_destroy();
+    init = !init;
+  }
+}
+
+
+static void before() {
+  if(!init) {
+    D_mm_init();
+    D_mm_pool_init(config);
+    init = !init;
+  }
+}
+
+
+
+
+
+static void free_zombie(zombie_t* z) {
+  *(z->i) = 0;
+}
+
+static zombie_t* new_zombie(int* i) {
+  zombie_t* zombie = D_mm_alloc(sizeof(zombie_t), (D_free_fnc_t)free_zombie);
+  zombie->i = i;
+  return zombie;
+}

--- a/test/src/mm_pool.c
+++ b/test/src/mm_pool.c
@@ -13,11 +13,8 @@ static D_mm_pool_conf config = {1, 2};
 static void free_zombie(zombie_t* z);
 static zombie_t* new_zombie(int* ptr);
 
-
 static void after();
 static void before();
-
-
 
 void TestPool_adds_doesnt_change_retain(CuTest *tc) {
   before();
@@ -30,7 +27,6 @@ void TestPool_adds_doesnt_change_retain(CuTest *tc) {
   CuAssertIntEquals(tc, 1, D_mm_retain_count(ptr));
   after();
 }
-
 
 void TestPool_fill_pool(CuTest *tc) {
   before();
@@ -76,8 +72,6 @@ void TestPool_fill_pool_free(CuTest *tc) {
   after();
 }
 
-
-
 static void after() {
   if(init) {
     D_mm_pool_destroy();
@@ -86,7 +80,6 @@ static void after() {
   }
 }
 
-
 static void before() {
   if(!init) {
     D_mm_init();
@@ -94,10 +87,6 @@ static void before() {
     init = !init;
   }
 }
-
-
-
-
 
 static void free_zombie(zombie_t* z) {
   *(z->i) = 0;


### PR DESCRIPTION
Retaining and Releasing Short living objects could make your code more complicated than it should, and can create an overhead of releasing objects all the time.

The solution is to save short living objects to a memory pool, that will be filled, and then, when each pool is full, a set of references will be 'released'. Creating 'weak references'. If some part of the code is using the reference, it still should retain it.

- [ ] Implement Tests